### PR TITLE
Using typed records [TEST]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ test/**/*.js.map
 
 # E2E test output
 e2e/robot/test_results
+.idea/

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "ts-helpers": "^1.1.1",
     "tslint": "^3.3.0",
     "tslint-loader": "^2.1.0",
+    "typed-immutable-record": "0.0.2",
     "typescript": "^1.8.10",
     "typings": "^1.0.4",
     "url-loader": "^0.5.7",

--- a/src/store/lineup/lineup.reducer.ts
+++ b/src/store/lineup/lineup.reducer.ts
@@ -1,5 +1,4 @@
-import { List, Record, fromJS } from 'immutable';
-import { ILineup, IParty, PartyRecord } from './lineup.types';
+import { ILineup } from './lineup.types';
 import { INITIAL_STATE } from './lineup.initial-state';
 
 import {

--- a/src/store/lineup/lineup.transformers.ts
+++ b/src/store/lineup/lineup.transformers.ts
@@ -1,10 +1,10 @@
-import { List, Map } from 'immutable';
-import { ILineup, IParty, PartyRecord } from './lineup.types';
+import { List } from 'immutable';
+import { ILineup, IParty, PartyFactory } from './lineup.types';
 
 export function deimmutifyLineup(state: ILineup): Object[] {
   return state.toJS();
 }
 
 export function reimmutifyLineup(plain): ILineup {
-  return List<IParty>(plain ? plain.map(PartyRecord) : []);
+  return List<IParty>(plain ? plain.map(PartyFactory) : []);
 }

--- a/src/store/lineup/lineup.types.ts
+++ b/src/store/lineup/lineup.types.ts
@@ -1,4 +1,8 @@
-import { List, Record } from 'immutable';
+import { List } from 'immutable';
+import {
+  TypedRecord,
+  makeTypedFactory
+} from 'typed-immutable-record/dist/index';
 
 export interface IParty {
   partyId: number;
@@ -6,9 +10,12 @@ export interface IParty {
   partyName: string;
 }
 
+export interface IPartyRecord extends TypedRecord<IPartyRecord>, IParty {
+}
+
 export type ILineup = List<IParty>;
 
-export const PartyRecord = Record({
+export const PartyFactory = makeTypedFactory<IParty, IPartyRecord>({
   partyId: 0,
   numberOfPeople: 0,
   partyName: '',

--- a/src/store/menu/menu.reducer.ts
+++ b/src/store/menu/menu.reducer.ts
@@ -1,4 +1,3 @@
-import { List, Record, fromJS } from 'immutable';
 import { IMenu } from './menu.types';
 import { INITIAL_STATE } from './menu.initial-state';
 

--- a/src/store/menu/menu.transformers.ts
+++ b/src/store/menu/menu.transformers.ts
@@ -1,10 +1,10 @@
-import { List, Map } from 'immutable';
-import { IMenu, IMenuItem, MenuItemRecord } from './menu.types';
+import { List } from 'immutable';
+import { IMenu, IMenuItem, MenuItemFactory } from './menu.types';
 
 export function deimmutifyMenu(state: IMenu): Object[] {
   return state.toJS();
 }
 
 export function reimmutifyMenu(plain): IMenu {
-  return List<IMenuItem>(plain ? plain.map(MenuItemRecord) : []);
+  return List<IMenuItem>(plain ? plain.map(MenuItemFactory) : []);
 }

--- a/src/store/menu/menu.types.ts
+++ b/src/store/menu/menu.types.ts
@@ -1,4 +1,8 @@
-import { List, Record } from 'immutable';
+import { List } from 'immutable';
+import {
+  TypedRecord,
+  makeTypedFactory
+} from 'typed-immutable-record/dist/index';
 
 export interface IMenuItem {
   menuId: string;
@@ -7,9 +11,13 @@ export interface IMenuItem {
   price: number;
 }
 
+export interface IMenuItemRecord extends TypedRecord<IMenuItemRecord>,
+  IMenuItem {
+}
+
 export type IMenu = List<IMenuItem>;
 
-export const MenuItemRecord = Record({
+export const MenuItemFactory = makeTypedFactory<IMenuItem, IMenuItemRecord>({
   menuId: '',
   description: '',
   stock: 0,

--- a/src/store/tables/tables.initial-state.ts
+++ b/src/store/tables/tables.initial-state.ts
@@ -1,5 +1,5 @@
 import { List, Map } from 'immutable';
-import { ITables, ITable, TableRecord } from './tables.types';
+import { ITables, ITable, TableFactory } from './tables.types';
 import { reimmutifyTables } from './tables.transformers';
 import { CLEAN } from '../../constants';
 

--- a/src/store/tables/tables.reducer.ts
+++ b/src/store/tables/tables.reducer.ts
@@ -1,5 +1,5 @@
 import { List, Record, fromJS } from 'immutable';
-import { ITables, ITable, TableRecord } from './tables.types';
+import { ITables, ITable, TableFactory } from './tables.types';
 import { INITIAL_STATE } from './tables.initial-state';
 
 import {

--- a/src/store/tables/tables.transformers.ts
+++ b/src/store/tables/tables.transformers.ts
@@ -1,5 +1,5 @@
 import { List, Map } from 'immutable';
-import { ITables, ITable, TableRecord } from './tables.types';
+import { ITables, ITable, TableFactory } from './tables.types';
 
 export function deimmutifyTables(state: ITables): Object[] {
   return state.toJS();
@@ -10,8 +10,9 @@ export function reimmutifyTables(plain): ITables {
 }
 
 function reimmutifyTable(table: any) {
-  return TableRecord(
+  return TableFactory(
     Object.assign({}, table, {
       order: Map<number, number>(table.order),
-    }));
+    })
+  );
 }

--- a/src/store/tables/tables.types.ts
+++ b/src/store/tables/tables.types.ts
@@ -1,4 +1,8 @@
 import { List, Record, Map } from 'immutable';
+import {
+  TypedRecord,
+  makeTypedFactory
+} from 'typed-immutable-record/dist/index';
 
 export interface ITable {
   id: number;
@@ -7,9 +11,12 @@ export interface ITable {
   order: Map<number, number>;
 }
 
+export interface ITableRecord extends TypedRecord<ITableRecord>, ITable {
+}
+
 export type ITables = List<ITable>;
 
-export const TableRecord = Record({
+export const TableFactory = makeTypedFactory<ITable, ITableRecord>({
   id: 0,
   numberOfSeats: 0,
   status: '',


### PR DESCRIPTION
@SethDavenport The result here is not a big deal at all. This is because the application has all state slices as Immutable.List so that it doesn't play with the returned methods/properties it could access from a Record object.
At least the refactoring was really easy and the app is still working.
I believe in real application the scenario would be different, since it could have multiple slices having a map that could be replaced with a `TypedRecord`, and all operations inside the reducer and even in the components that would be subscribing to the changes would be typed.
